### PR TITLE
Adding MAX_TIMEOUT for process exit

### DIFF
--- a/client.py
+++ b/client.py
@@ -10,6 +10,7 @@ TARGET_PATH = 'C:\\Program Files\\Windows NT\\Accessories\\wordpad.exe'
 TARGET_ARGS = ''
 MAX_ATTEMPTS = 3
 WAIT_TIME = 5
+MAX_TIMEOUT = 60
 
 
 def main():
@@ -34,7 +35,7 @@ def main():
         sys.exit()
 
     # Start tracing
-    tracer = TraceInserter(host, port, DYNAMO_PATH, TARGET_PATH, TARGET_ARGS, WAIT_TIME)
+    tracer = TraceInserter(host, port, DYNAMO_PATH, TARGET_PATH, TARGET_ARGS, WAIT_TIME, MAX_TIMEOUT)
     while tracer.ready():
         tracer.go()
     else:

--- a/trace_inserter.py
+++ b/trace_inserter.py
@@ -8,12 +8,13 @@ from trace_runner import TraceRunner
 
 
 class TraceInserter:
-    def __init__(self, host, port, drio_path, target_path, target_args, wait_time):
+    def __init__(self, host, port, drio_path, target_path, target_args, wait_time, max_timeout):
         self.bs = beanstalkc.Connection(host, port)
         self.d_path = drio_path
         self.t_path = target_path
         self.t_args = target_args
         self.w_time = wait_time
+        self.max_timeout = max_timeout
 
         self.job = None
         self.s_name = None
@@ -58,7 +59,7 @@ class TraceInserter:
     def insert(self):
         for i in range(0, 3):
             try:
-                runner = TraceRunner(self.d_path, self.t_path, self.t_args, self.s_name, self.s_path, self.w_time)
+                runner = TraceRunner(self.d_path, self.t_path, self.t_args, self.s_name, self.s_path, self.w_time, self.max_timeout)
 
                 # Run trace
                 runner.go()

--- a/trace_runner.py
+++ b/trace_runner.py
@@ -60,11 +60,12 @@ class TraceRunner:
                             if cpu is not None and cpu is True:
                                 self.kill(child.pid)
                                 break
-                            end_time = time()
-                            elapsed = end_time - self.start_time
-                            if elapsed > self.max_timeout:
-                                self.kill(child.pid)
-                                break
+                            if self.max_timeout is not None or self.max_timeout != 0:
+                                end_time = time()
+                                elapsed = end_time - self.start_time
+                                if elapsed > self.max_timeout:
+                                    self.kill(child.pid)
+                                    break
         except psutil.NoSuchProcess:
             pass
 

--- a/trace_runner.py
+++ b/trace_runner.py
@@ -1,26 +1,28 @@
-import glob
 import os
+import glob
 import shlex
-import shutil
-import subprocess
-import tempfile
-from time import sleep
-
 import psutil
+import shutil
+import tempfile
+import subprocess
+from time import sleep, time
 
 
 class TraceRunner:
-    def __init__(self, dynamo_path, target_path, target_args, seed_name, seed_path, wait_time):
+    def __init__(self, dynamo_path, target_path, target_args, seed_name, seed_path, wait_time, max_timeout):
         self.d_path = dynamo_path
         self.t_path = target_path
         self.t_args = target_args
         self.s_name = seed_name
         self.s_path = seed_path
         self.wait = wait_time
+        self.max_timeout = max_timeout
 
         self.t_name = os.path.basename(target_path)
         self.l_path = tempfile.mkdtemp()
         self.null = open(os.devnull, 'w')
+
+        self.start_time = None
 
         self.proc = None
         self.ppid = None
@@ -39,6 +41,8 @@ class TraceRunner:
         command = [self.d_path, '-t', 'drcov', '-dump_text', '-logdir', self.l_path, '--', self.t_path, self.t_args, self.s_path]
         self.proc = subprocess.Popen(command, stdout=self.null, stderr=subprocess.STDOUT)
 
+        self.start_time = time()
+
         sleep(self.wait)
         self.check()
 
@@ -56,6 +60,11 @@ class TraceRunner:
                             if cpu is not None and cpu is True:
                                 self.kill(child.pid)
                                 break
+                            end_time = time()
+                            elapsed = end_time - self.start_time
+                            if elapsed > self.max_timeout:
+                                self.kill(child.pid)
+                                break
         except psutil.NoSuchProcess:
             pass
 
@@ -66,7 +75,7 @@ class TraceRunner:
         for i in range(0, 20):
             if self.proc.poll() is None:
                 try:
-                    command = "taskkill /PID %s " % pid
+                    command = "taskkill /PID %s /T" % pid
                     subprocess.call(shlex.split(command), stdout=self.null, stderr=subprocess.STDOUT)
                 except:
                     print "[ +E+ ] - Error killing process."
@@ -77,7 +86,7 @@ class TraceRunner:
         # If process is still running, kill it forcefully
         sleep(2)
         if self.proc.poll() is None:
-            command = "taskkill /F /PID %s " % pid
+            command = "taskkill /F /PID %s /T" % pid
             subprocess.call(shlex.split(command), stdout=self.null, stderr=subprocess.STDOUT)
 
     def clean(self):


### PR DESCRIPTION
Hi @pyoor 

This commit resolve's the issue with some processes whose CPU does not become near **NULL**. In that case, the process keeps on running and wastes the CPU cycles. Due to this reason, I have added `MAX_TIMEOUT` in distiller. 

I have also added `/T` argument to `taskkill` so that the termination signal is also sent to the child process if any. Also, I have arranged some imports according the character length.

Please review the changes and merge the pull request.

Thanks.
